### PR TITLE
Get accessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+- '4'
+- '6'
+notifications:
+  slack:
+    secure: KF6oKsIXnFym5rbJ8tt5Nq3flha8xaOLvu0SkFMjpC9oqRd9y8h/AM2BdUU2gVUUy28VuZeYKKL0BEA2X6dHiG9NLabFUlwefoiQLD5CjKVNIYOkG18hN98ijeCM+VwFy8Lj50xxaCpvy7y+sVcCjPuH9ZAboLFiZ7/0nx1uwGkTJDFCGDb+8NIGWsvpKlCbNBjkQblw7GdLegCCZiZuEa1H029eTQtSCKpdViCnWRFO9YKSO6gmsVWdTeRDdbWEbC6tfVBzt8s18o+38ZtdillZNMEW0+XX/hakRFTAP5A5Druhdp+Wpe1cTVPnTdFCNIKifnHFHShS07THv1e07KzYtvxAOvZmdLA4ptjBIHL17+2UYQ5vZ8tWrxNGEb7KhnmJ2Jw2o6/F35AxEt+osJ7/CaJI5jShu8k8j2NM7YyuYMIrwlo0vwK6bOQbF/V3kQue7WaP/5noBQzCCH5d9UpsoaO5CoMlnp0uvAD8qZ+hpOX/zcwATT0nll8w/oWM87AVzne86703r4vpDM6zuo2P+cUBf/XBV83sXujgPro7Gcb/wJQlWfXM2xX73iyuNXZi8rW+ODRTFAz8YSzNa4jgwz8u+5RHyGxIouFWaVnjedv1hkkigmneuERQX/8dWwHsbnvs5V/rr0o4Q+FQBn/I4SC72ae8/Ge+nz74n4A=
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# slack-message-builder
-Library for building and manipulating messages for the Slack API
+[![Sponsored by Beep Boop](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F_sponsored_by-%E2%9C%A8_Robots%20%26%20Pencils%20%2F%20Beep%20Boop_%E2%9C%A8-FB6CBE.svg)](https://beepboophq.com)
+[![Build Status](https://travis-ci.org/BeepBoopHQ/slack-message-builder.svg)](https://travis-ci.org/BeepBoopHQ/slack-message-builder)
+[![Coverage Status](https://coveralls.io/repos/github/BeepBoopHQ/slack-message-builder/badge.svg)](https://coveralls.io/github/BeepBoopHQ/slack-message-builder)
+
+# Slack Message Builder
+
+## Install
+
+```
+npm install --save slack-message-builder
+```

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -12,13 +12,13 @@ class Attachment {
       values = { text: values }
     }
     this._message = null
-    this._actions = []
-    this._fields = []
     this.data = {
       text: ''
     }
 
     setValues(this, values)
+    // Adds scope of `this` to each setter fn for chaining `.get()`
+    this.addSetterScopes()
   }
 
   message (message) {
@@ -31,7 +31,10 @@ class Attachment {
   field (values) {
     var field = Field(values).attachment(this)
 
-    this._fields.push(field)
+    if (!this.data.fields) {
+      this.data.fields = []
+    }
+    this.data.fields.push(field)
 
     return field
   }
@@ -40,7 +43,10 @@ class Attachment {
   button () {
     var button = Button.apply(Button, arguments).attachment(this)
 
-    this._actions.push(button)
+    if (!this.data.actions) {
+      this.data.actions = []
+    }
+    this.data.actions.push(button)
 
     return button
   }
@@ -48,11 +54,11 @@ class Attachment {
   // this.actions() sends here, since button feels more intuitive
   buttons (buttons) {
     if (buttons === null) {
-      this._actions = null
+      this.data.actions = null
       return this
     }
 
-    this._actions = (buttons || []).map(action => this.action(action))
+    this.data.actions = (buttons || []).map(action => this.action(action))
 
     return this
   }
@@ -69,12 +75,12 @@ class Attachment {
   json () {
     var attachment = Object.assign({}, this.data)
 
-    if (this._actions.length > 0) {
-      attachment.actions = this._actions.map(action => action.json())
+    if (this.data.actions && this.data.actions.length > 0) {
+      attachment.actions = this.data.actions.map(action => action.json())
     }
 
-    if (this._fields.length > 0) {
-      attachment.fields = this._fields.map(field => field.json())
+    if (this.data.fields && this.data.fields.length > 0) {
+      attachment.fields = this.data.fields.map(field => field.json())
     }
 
     return attachment
@@ -102,11 +108,11 @@ const PROPS = {
   'ts': true, // epoch time
   'fields': function (fields) {
     if (fields === null) {
-      this._fields = null
+      this.data.fields = null
       return this
     }
 
-    this._fields = (fields || []).map(field => this.field(field))
+    this.data.fields = (fields || []).map(field => this.field(field))
 
     return this
   },

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -39,8 +39,13 @@ class Attachment {
     return field
   }
 
-  // creates Button instance, adds it to collection and returns it
+  // alias for `this.action()`
   button () {
+    return this.action.apply(this, arguments)
+  }
+
+  // creates Button instance, adds it to collection and returns it
+  action () {
     var button = Button.apply(Button, arguments).attachment(this)
 
     if (!this.data.actions) {
@@ -49,23 +54,6 @@ class Attachment {
     this.data.actions.push(button)
 
     return button
-  }
-
-  // this.actions() sends here, since button feels more intuitive
-  buttons (buttons) {
-    if (buttons === null) {
-      this.data.actions = null
-      return this
-    }
-
-    this.data.actions = (buttons || []).map(action => this.action(action))
-
-    return this
-  }
-
-  // proxy to `this.button()` for convenience since Slack API calls them actions
-  action () {
-    return this.button.apply(this, arguments)
   }
 
   end () {
@@ -86,27 +74,31 @@ class Attachment {
     return attachment
   }
 
+  toJSON () {
+    return this.json()
+  }
+
 }
 
 // props for Slack API - true gets a generic setter fn
 const PROPS = {
-  'text': true,
-  'title': true,
-  'title_link': true,
-  'fallback': true,
-  'callback_id': true,
-  'color': true,
-  'pretext': true,
-  'author_name': true,
-  'author_link': true,
-  'author_icon': true,
-  'image_url': true,
-  'thumb_url': true,
-  'footer': true,
-  'footer_icon': true,
-  'mrkdwn_in': true,
-  'ts': true, // epoch time
-  'fields': function (fields) {
+  text: true,
+  title: true,
+  title_link: true,
+  fallback: true,
+  callback_id: true,
+  color: true,
+  pretext: true,
+  author_name: true,
+  author_link: true,
+  author_icon: true,
+  image_url: true,
+  thumb_url: true,
+  footer: true,
+  footer_icon: true,
+  mrkdwn_in: true,
+  ts: true, // epoch time
+  fields (fields) {
     if (fields === null) {
       this.data.fields = null
       return this
@@ -116,9 +108,18 @@ const PROPS = {
 
     return this
   },
-  'actions': function (actions) {
-    return this.buttons(actions)
-  }
+  actions (actions) {
+    if (actions === null) {
+      this.data.actions = null
+      return this
+    }
+
+    this.data.actions = (actions || []).map(action => this.action(action))
+
+    return this
+  },
+  // alias for actions
+  buttons: 'actions'
 }
 
 mixinSetters(Attachment.prototype, PROPS)

--- a/src/button.js
+++ b/src/button.js
@@ -35,16 +35,6 @@ class Button {
     return this
   }
 
-  val (val) {
-    if (val !== null && val !== undefined && typeof val === 'object') {
-      val = JSON.stringify(val)
-    }
-
-    this.data.value = val
-
-    return this
-  }
-
   end () {
     return this._attachment
   }
@@ -58,18 +48,30 @@ class Button {
 
     return button
   }
+
+  toJSON () {
+    return this.json()
+  }
 }
 
 // props for Slack API - true gets a generic setter fn
 const PROPS = {
-  'name': true,
-  'text': true,
-  'style': true,
-  'type': true,
-  'value': function (val) {
-    return this.val(val)
+  name: true,
+  text: true,
+  style: true,
+  type: true,
+  value: function (val) {
+    if (val !== null && val !== undefined && typeof val === 'object') {
+      val = JSON.stringify(val)
+    }
+
+    this.data.value = val
+
+    return this
   },
-  'confirm': function (confirm) {
+  // alias for value
+  val: 'value',
+  confirm: function (confirm) {
     if (confirm === null) {
       this.data.confirm = null
       return this

--- a/src/button.js
+++ b/src/button.js
@@ -20,12 +20,13 @@ class Button {
     }
 
     this._attachment = null
-    this._confirm = null
     this.data = {
       type: 'button'
     }
 
     setValues(this, values)
+    // Adds scope of `this` to each setter fn for chaining `.get()`
+    this.addSetterScopes()
   }
 
   attachment (attachment) {
@@ -51,8 +52,8 @@ class Button {
   json () {
     var button = Object.assign({}, this.data)
 
-    if (this._confirm) {
-      button.confirm = this._confirm.json()
+    if (this.data.confirm) {
+      button.confirm = this.data.confirm.json()
     }
 
     return button
@@ -70,13 +71,13 @@ const PROPS = {
   },
   'confirm': function (confirm) {
     if (confirm === null) {
-      this._confirm = null
+      this.data.confirm = null
       return this
     }
 
-    this._confirm = Confirm(confirm).button(this)
+    this.data.confirm = Confirm(confirm).button(this)
 
-    return this._confirm
+    return this.data.confirm
   }
 }
 

--- a/src/confirm.js
+++ b/src/confirm.js
@@ -9,6 +9,8 @@ class Confirm {
     this.data = {}
 
     setValues(this, values)
+    // Adds scope of `this` to each setter fn for chaining `.get()`
+    this.addSetterScopes()
   }
 
   button (button) {

--- a/src/confirm.js
+++ b/src/confirm.js
@@ -19,20 +19,6 @@ class Confirm {
     return this
   }
 
-  // convenience fn for ok_text
-  ok (val) {
-    this.data.ok_text = val
-
-    return this
-  }
-
-  // convenience fn for dismiss_text
-  dismiss (val) {
-    this.data.dismiss_text = val
-
-    return this
-  }
-
   end () {
     return this._button
   }
@@ -41,18 +27,22 @@ class Confirm {
     return Object.assign({}, this.data)
   }
 
+  toJSON () {
+    return this.json()
+  }
+
 }
 
 // props for Slack API - true gets a generic setter fn
 const PROPS = {
-  'title': true,
-  'text': true,
-  'ok_text': function (val) {
-    return this.ok(val)
-  },
-  'dismiss_text': function (val) {
-    return this.dismiss(val)
-  }
+  title: true,
+  text: true,
+  ok_text: true,
+  // alias for ok_text
+  ok: 'ok_text',
+  dismiss_text: true,
+  // alias for dismiss_text
+  dismiss: 'dismiss'
 }
 
 mixinSetters(Confirm.prototype, PROPS)

--- a/src/field.js
+++ b/src/field.js
@@ -30,13 +30,17 @@ class Field {
   json () {
     return Object.assign({}, this.data)
   }
+
+  toJSON () {
+    return this.json()
+  }
 }
 
 // props for Slack API - true gets a generic setter fn
 const PROPS = {
-  'title': true,
-  'value': true,
-  'short': true
+  title: true,
+  value: true,
+  short: true
 }
 
 mixinSetters(Field.prototype, PROPS)

--- a/src/field.js
+++ b/src/field.js
@@ -13,6 +13,8 @@ class Field {
     this.data = {}
 
     setValues(this, values)
+    // Adds scope of `this` to each setter fn for chaining `.get()`
+    this.addSetterScopes()
   }
 
   attachment (attachment) {

--- a/src/message.js
+++ b/src/message.js
@@ -14,18 +14,22 @@ const Message = module.exports = class {
       values.text = text
     }
 
-    this._attachments = []
     this.data = {}
 
     // populate any properties passed into constructor
-    setValues(this, values)
+    setValues(this, values, PROPS)
+    // Adds scope of `this` to each setter fn for chaining `.get()`
+    this.addSetterScopes()
   }
 
   // should create an Attachment object and add it to the collection
   attachment (values) {
     var attachment = Attachment(values).message(this)
 
-    this._attachments.push(attachment)
+    if (!this.data.attachments) {
+      this.data.attachments = []
+    }
+    this.data.attachments.push(attachment)
 
     return attachment
   }
@@ -34,8 +38,8 @@ const Message = module.exports = class {
   json () {
     var message = Object.assign({}, this.data)
 
-    if (this._attachments.length > 0) {
-      message.attachments = this._attachments.map(attachment => attachment.json())
+    if (this.data.attachments && this.data.attachments.length > 0) {
+      message.attachments = this.data.attachments.map(attachment => attachment.json())
     }
 
     return message
@@ -59,11 +63,12 @@ const PROPS = {
   'icon_url': true,
   'attachments': function (attachments) {
     if (attachments === null) {
-      this._attachments = null
+      this.data.attachments = null
       return this
     }
 
-    this._attachments = (attachments || []).map(attachment => {
+    // TODO: remove reassignment here, just wipe then set
+    this.data.attachments = (attachments || []).map(attachment => {
       return this.attachment(attachment)
     })
 

--- a/src/message.js
+++ b/src/message.js
@@ -45,23 +45,27 @@ const Message = module.exports = class {
     return message
   }
 
+  toJSON () {
+    return this.json()
+  }
+
 }
 
 // props for Slack API - true gets a generic setter fn
 const PROPS = {
-  'text': true,
-  'response_type': true,
-  'replace_original': true,
-  'delete_original': true,
-  'token': true,
-  'channel': true,
-  'parse': true,
-  'link_names': true,
-  'unfurl_links': true,
-  'unfurl_media': true,
-  'as_user': true,
-  'icon_url': true,
-  'attachments': function (attachments) {
+  text: true,
+  response_type: true,
+  replace_original: true,
+  delete_original: true,
+  token: true,
+  channel: true,
+  parse: true,
+  link_names: true,
+  unfurl_links: true,
+  unfurl_media: true,
+  as_user: true,
+  icon_url: true,
+  attachments: function (attachments) {
     if (attachments === null) {
       this.data.attachments = null
       return this
@@ -75,14 +79,14 @@ const PROPS = {
     return this
   },
   // bot's username for msg - as_user must be true, or ignored
-  'username': function (val) {
+  username: function (val) {
     this.data.username = val
     this.data.as_user = true
 
     return this
   },
   // as_user must be false, or ignored
-  'icon_emoji': function (val) {
+  icon_emoji: function (val) {
     this.data.icon_emoji = val
     this.data.as_user = false
 

--- a/src/mixin-setters.js
+++ b/src/mixin-setters.js
@@ -9,7 +9,7 @@ module.exports = (receiver, props) => {
     var propVal = props[prop]
     var fnName = camelcase(prop)
 
-    // Add generic setter fn
+    // generic setter fn
     if (propVal === true) {
       setterFn = function (val) {
         this.data[prop] = val
@@ -18,7 +18,15 @@ module.exports = (receiver, props) => {
       }
     }
 
-    // Add custom setter fn
+    // alias setter fn
+    if (typeof propVal === 'string') {
+      prop = propVal
+      setterFn = function () {
+        return this[propVal].apply(this, arguments)
+      }
+    }
+
+    // custom setter fn
     if (typeof propVal === 'function') {
       setterFn = propVal
     }
@@ -34,7 +42,6 @@ module.exports = (receiver, props) => {
         }
 
         var val = scope.data[prop]
-        console.log('getter() ', fnName, idx, val, scope.data, prop)
 
         // return indexed value
         if (idx !== undefined && Array.isArray(val)) {

--- a/test/attachment.test.js
+++ b/test/attachment.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('ava').test
-// const camelcase = require('camelcase')
+const camelcase = require('camelcase')
 const Attachment = require('../src/attachment')
 
 test('Atachment()', t => {
@@ -119,21 +119,44 @@ test('Attachment().field()', t => {
   t.is(a.fields[0].short, short)
 })
 
-// test.only('Attachment() property get()', t => {
-//   var a = Attachment(attachment)
+test('Attachment() property get()', t => {
+  var a = Attachment(attachment)
 
-//   Object.keys(attachment).forEach(prop => {
-//     var val = attachment[prop]
-//     var getVal = a[camelcase(prop)].get()
+  Object.keys(attachment).forEach(prop => {
+    var val = attachment[prop]
+    var getVal = a[camelcase(prop)].get()
 
-//     if (typeof getVal.json === 'function') {
-//       t.deepEqual(getVal.json(), val)
-//     } else {
-//       t.is(getVal, val)
-//     }
-//   })
-//   t.is(a.text.get(), attachment.text)
-// })
+    // Flattens object out and normalizes to json structure
+    var jsonGetVal = JSON.parse(JSON.stringify(getVal))
+    t.deepEqual(jsonGetVal, val, `${prop} does not match`)
+  })
+})
+
+test('Attachment().actions.get()', t => {
+  var a = Attachment()
+    .actions(attachment.actions)
+
+  t.deepEqual(JSON.parse(JSON.stringify(a.actions.get())), attachment.actions)
+})
+
+test('Attachment().buttons.get()', t => {
+  var a = Attachment()
+    .buttons(attachment.actions)
+
+  t.true(Array.isArray(a.buttons.get()))
+  t.is(a.buttons.get().length, attachment.actions.length)
+  t.deepEqual(JSON.parse(JSON.stringify(a.buttons.get())), attachment.actions)
+})
+
+test('Attachment().actions.get() w/ index', t => {
+  var a = Attachment()
+    .actions(attachment.actions)
+
+  t.deepEqual(JSON.parse(JSON.stringify(a.actions.get(0))), attachment.actions[0])
+  t.deepEqual(JSON.parse(JSON.stringify(a.actions.get(1))), attachment.actions[1])
+  t.deepEqual(JSON.parse(JSON.stringify(a.actions.get(-1))), attachment.actions[1])
+  t.deepEqual(JSON.parse(JSON.stringify(a.actions.get(-2))), attachment.actions[0])
+})
 
 const attachment = {
   text: 'attachment text',

--- a/test/attachment.test.js
+++ b/test/attachment.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('ava').test
+// const camelcase = require('camelcase')
 const Attachment = require('../src/attachment')
 
 test('Atachment()', t => {
@@ -117,6 +118,22 @@ test('Attachment().field()', t => {
   t.is(a.fields[0].value, value)
   t.is(a.fields[0].short, short)
 })
+
+// test.only('Attachment() property get()', t => {
+//   var a = Attachment(attachment)
+
+//   Object.keys(attachment).forEach(prop => {
+//     var val = attachment[prop]
+//     var getVal = a[camelcase(prop)].get()
+
+//     if (typeof getVal.json === 'function') {
+//       t.deepEqual(getVal.json(), val)
+//     } else {
+//       t.is(getVal, val)
+//     }
+//   })
+//   t.is(a.text.get(), attachment.text)
+// })
 
 const attachment = {
   text: 'attachment text',


### PR DESCRIPTION
This PR adds a `get()` function to all property setter functions.

```js
message.attachments.get() // returns array of attachment objects

message.attachments.get(0) // returns first attachment object

message.attachments.get(-1) // returns last attachment object

message.text.get() // returns text value
```

This will be useful for modifying an existing message object, like replacing the buttons on the last attachment with a text only attachment:

```
message.attachments.get(-1)
  .buttons(null) // clear any existing buttons
  .text('You clicked a button')
```

In order to access the correct scope when calling `.get()` on a setter function, needed to copy the scope object and set it on the setter function itself.  Not super happy with this, but it's not part of any public api.  After implementing this I wonder if there's a cleaner way to do this with `Object.defineProperty`.

Refactored a few things in there to make this happen:

+ Moved property values to the `data` object on instances. Previously had the complex object instances stored directly on the object, i.e. `message._attachments` is not stored in `message.data.attachments`
+ Formalized ability to define an alias for properties, i.e. `buttons=>actions`
+ Also plugging in ci
