### PR TITLE
logic on username/as_user dep is flipped

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -78,10 +78,10 @@ const PROPS = {
 
     return this
   },
-  // bot's username for msg - as_user must be true, or ignored
+  // bot's username for msg - as_user must be false, or ignored
   username: function (val) {
     this.data.username = val
-    this.data.as_user = true
+    this.data.as_user = false
 
     return this
   },

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -135,6 +135,15 @@ test('slackmessage().attachments.get() w/ index', t => {
   t.deepEqual(JSON.parse(JSON.stringify(m.attachments.get(-2))), message.attachments[0])
 })
 
+test('slackmessage().username()', t => {
+  var m = sm()
+    .username('test')
+    .json()
+
+  t.is(m.username, 'test')
+  t.false(m.as_user)
+})
+
 const message = {
   text: 'message text',
   response_type: 'ephemeral',


### PR DESCRIPTION
Fixes incorrect value set for `as_user` when `username` is set.  Should be setting `as_user` to `false` instead of `true` per the Slack API Docs:

https://api.slack.com/methods/chat.postMessage

