### PR TITLE
adding thread_ts property to message

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -66,6 +66,7 @@ const PROPS = {
   as_user: true,
   icon_url: true,
   thread_ts: true,
+  reply_broadcast: true,
   attachments: function (attachments) {
     if (attachments === null) {
       this.data.attachments = null

--- a/src/message.js
+++ b/src/message.js
@@ -65,6 +65,7 @@ const PROPS = {
   unfurl_media: true,
   as_user: true,
   icon_url: true,
+  thread_ts: true,
   attachments: function (attachments) {
     if (attachments === null) {
       this.data.attachments = null

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -37,6 +37,7 @@ test('slackmessage() with chained setters', t => {
     .unfurlMedia(message.unfurl_media)
     .asUser(message.as_user)
     .iconUrl(message.icon_url)
+    .threadTs(message.thread_ts)
     .attachments(message.attachments)
     .json()
 
@@ -57,6 +58,7 @@ test('slackmessage() with chained setters and chained attachment', t => {
     .unfurlMedia(message.unfurl_media)
     .asUser(message.as_user)
     .iconUrl(message.icon_url)
+    .threadTs(message.thread_ts)
     .attachment()
       .text(message.attachments[0].text)
       .title(message.attachments[0].title)
@@ -157,6 +159,7 @@ const message = {
   unfurl_media: false,
   as_user: false,
   icon_url: 'https://beepboophq.com/icon',
+  thread_ts: '1231231231312312',
   attachments: [
     {
       text: 'attachment text',

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -38,6 +38,7 @@ test('slackmessage() with chained setters', t => {
     .asUser(message.as_user)
     .iconUrl(message.icon_url)
     .threadTs(message.thread_ts)
+    .replyBroadcast(message.reply_broadcast)
     .attachments(message.attachments)
     .json()
 
@@ -59,6 +60,7 @@ test('slackmessage() with chained setters and chained attachment', t => {
     .asUser(message.as_user)
     .iconUrl(message.icon_url)
     .threadTs(message.thread_ts)
+    .replyBroadcast(message.reply_broadcast)
     .attachment()
       .text(message.attachments[0].text)
       .title(message.attachments[0].title)
@@ -160,6 +162,7 @@ const message = {
   as_user: false,
   icon_url: 'https://beepboophq.com/icon',
   thread_ts: '1231231231312312',
+  reply_broadcast: true,
   attachments: [
     {
       text: 'attachment text',


### PR DESCRIPTION
This PR adds the `thread_ts` and `reply_broadcast` properties to the message object.  This is in response to Slack releasing threaded messages, which are controlled via this property.

```javascript
// To make a message part of a thread and relay it back to channel
msg
  .threadTs(parent.ts)
  .replyBroadcast(true)
```