### PR TITLE
changing prop custom setters to use snake_case for consistency

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -87,7 +87,7 @@ const PROPS = {
     return this
   },
   // as_user must be false, or ignored
-  iconEmoji: function (val) {
+  icon_emoji: function (val) {
     this.data.icon_emoji = val
     this.data.as_user = false
 

--- a/src/select.js
+++ b/src/select.js
@@ -84,7 +84,7 @@ const PROPS = {
 
     return this.data.confirm
   },
-  selectedOption: function (text, value) {
+  selected_option: function (text, value) {
     if (value !== null && value !== undefined && typeof value === 'object') {
       value = JSON.stringify(value)
     }

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -162,9 +162,12 @@ test('slackmessage().attachments() w/ null', t => {
   t.is(m.data.attachments, null)
 })
 
-test('slackmessage().icon_emoji()', t => {
-  var m = sm()
-    .iconEmoji(iconEmoji)
+test('slackmessage().iconEmoji()', t => {
+  var m = sm().asUser(true)
+
+  t.true(m.data.as_user)
+
+  m = m.iconEmoji(iconEmoji)
 
   t.truthy(m)
   t.is(m.data.icon_emoji, iconEmoji)


### PR DESCRIPTION
This updates a few custom prop setter functions to use the `snake_case` name that matches the name in the slack api.  It has no effect on the external api exposed as they are automatically `camelCased` when added to the different object prototypes.  Tests are covering each of these changes as well.